### PR TITLE
s/wx.Color/wx.Colour/g - fix for wxPython 2.9.x

### DIFF
--- a/passagewidget.py
+++ b/passagewidget.py
@@ -360,12 +360,12 @@ class PassageWidget:
 
         def dim (c, dim):
             """Lowers a color's alpha if dim is true."""
-            if isinstance(c, wx.Color): c = list(c.Get(includeAlpha = True))
+            if isinstance(c, wx.Colour): c = list(c.Get(includeAlpha = True))
             if len(c) < 4:
                 c = list(c)
                 c.append(255)
             if dim: c[3] *= PassageWidget.DIMMED_ALPHA
-            return wx.Color(c[0], c[1], c[2], c[3])
+            return wx.Colour(c[0], c[1], c[2], c[3])
 
         # set up our buffer
 
@@ -533,7 +533,7 @@ class PassageWidget:
             
             if isinstance(gc, wx.GraphicsContext):
                 r, g, b = color.Get()
-                color = wx.Color(r, g, b, 64)
+                color = wx.Colour(r, g, b, 64)
                 gc.SetBrush(wx.Brush(color))
             else:
                 gc.SetBrush(wx.TRANSPARENT_BRUSH)

--- a/storypanel.py
+++ b/storypanel.py
@@ -744,7 +744,7 @@ class StoryPanel (wx.ScrolledWindow):
                 marqueeColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT)
                 gc.SetPen(wx.Pen(marqueeColor))
                 r, g, b = marqueeColor.Get()
-                marqueeColor = wx.Color(r, g, b, StoryPanel.MARQUEE_ALPHA)            
+                marqueeColor = wx.Colour(r, g, b, StoryPanel.MARQUEE_ALPHA)
                 gc.SetBrush(wx.Brush(marqueeColor))
                 
             gc.DrawRectangle(self.dragRect.x, self.dragRect.y, self.dragRect.width, self.dragRect.height)


### PR DESCRIPTION
wxPython 2.9.something seems to have removed the "wx.Color" alias that existed for the "wx.Colour" class. This should work on wxPython 2.8.x too.
