### PR TITLE
Avoid localized month name in build date

### DIFF
--- a/tiddlywiki.py
+++ b/tiddlywiki.py
@@ -108,7 +108,7 @@ class TiddlyWiki:
 		# Insert version number
 		output = output.replace('"VERSION"', "Made in " + app.NAME + " " + app.VERSION)
 		# Insert timestamp
-		output = output.replace('"TIME"', "Built on "+time.strftime("%d %b %Y at %H:%M:%S, %z"))
+		output = output.replace('"TIME"', "Built on "+time.strftime("%Y-%m-%d at %H:%M:%S, %z"))
 		
 		# Insert the test play "start at passage" value
 		if (startAt):


### PR DESCRIPTION
A localized month name can contain non-ASCII characters, which will be
inserted in the string in a locale-specific encoding by strftime().
This can lead to problems: see this forum thread for an example where
an a-umlaut in a Swedish month name led to a build failure:
  http://twinery.org/forum/index.php/topic,756.0.html

I picked the ISO 8601 date format for the numeric-only date.
