### PR TITLE
Fix positioning of New Passages

### DIFF
--- a/storypanel.py
+++ b/storypanel.py
@@ -95,7 +95,7 @@ class StoryPanel (wx.ScrolledWindow):
                 type = "Untitled Passage"
             title = self.untitledName(type)
         if not pos: pos = StoryPanel.INSET
-        if not logicals: qspos = self.toLogical(pos)
+        if not logicals: pos = self.toLogical(pos)
 		
         new = PassageWidget(self, self.app, title = title, text = text, tags = tags, pos = pos)
         self.widgets.append(new)


### PR DESCRIPTION
Currently when a new passage ("Untitled Passage X" ) is created it will appear as near to the top of the Story Panel as possible, which may be off screen if they used has paged down.

This is due to a bug introduced into the newWidget method back in 09-sep-2013.

The call to self.toLogical(pos) was changed to stored its return within the "qspos" variable, which is never used.

Fixed in branch "i012_position_new_passage"
