### PR TITLE
Support HTML import of SugarCube-based stories

### DIFF
--- a/tiddlywiki.py
+++ b/tiddlywiki.py
@@ -253,7 +253,7 @@ class TiddlyWiki:
 	def addHtml (self, source):
 		
 		"""Adds HTML source code to this TiddlyWiki."""	
-		divs = re.search(r'<div\sid=["\']?storeArea["\']?>(.*)</div>', source,
+		divs = re.search(r'<div\sid=["\']?store(?:A|-a)rea["\']?>(.*)</div>', source,
 						re.DOTALL)
 		if divs:
 			divs = divs.group(1);


### PR DESCRIPTION
I saw there is a modular header effort being done by greyelf. SugarCube edit and output support should go there, but I think import support belongs in the base code instead, since there is no detection of the header done on import and the header of the story being imported into might not match the header of the imported HTML.
