### PR TITLE
Enable high-DPI (Retina) text rendering in Passage editors.

### DIFF
--- a/fseditframe.py
+++ b/fseditframe.py
@@ -54,6 +54,7 @@ class FullscreenEditFrame (wx.Frame):
         self.editCtrl.SetUseHorizontalScrollBar(False)
         self.editCtrl.SetUseVerticalScrollBar(False)
         self.editCtrl.SetCaretPeriod(750)
+        self.editCtrl.SetBufferedDraw(False)
         
         self.directions = wx.StaticText(self.panel, label = FullscreenEditFrame.DIRECTIONS, style = wx.ALIGN_CENTRE)
         labelFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)

--- a/passageframe.py
+++ b/passageframe.py
@@ -151,6 +151,7 @@ class PassageFrame (wx.Frame):
         self.bodyInput.SetWrapMode(wx.stc.STC_WRAP_WORD)
         self.bodyInput.SetSelBackground(True, wx.SystemSettings_GetColour(wx.SYS_COLOUR_HIGHLIGHT))
         self.bodyInput.SetSelForeground(True, wx.SystemSettings_GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT))
+        self.bodyInput.SetBufferedDraw(False)
 
         # The default keyboard shortcuts for StyledTextCtrl are
         # nonstandard on Mac OS X


### PR DESCRIPTION
Disabling buffered drawing means text is rendered directly. This
could cause flickering, so if there' a way to increase the
resolution of the buffer rather than disabling it entirely,
that would probably be preferable.

Solution taken from:

https://groups.google.com/forum/#!topic/scintilla-interest/tj71w3UMj4s

This fixes the first item in issue #114
