### PR TITLE
Add StoryInit feature

### DIFF
--- a/storyframe.py
+++ b/storyframe.py
@@ -282,6 +282,9 @@ class StoryFrame (wx.Frame):
         self.storySettingsMenu.Append(StoryFrame.STORYSETTINGS_INCLUDES, 'StoryIncludes')
         self.Bind(wx.EVT_MENU, self.createInfoPassage, id = StoryFrame.STORYSETTINGS_INCLUDES)
         
+        self.storySettingsMenu.Append(StoryFrame.STORYSETTINGS_INIT, 'StoryInit')
+        self.Bind(wx.EVT_MENU, self.createInfoPassage, id = StoryFrame.STORYSETTINGS_INIT)
+
         self.storyMenu.AppendMenu(wx.ID_ANY, 'Special Passages', self.storySettingsMenu)
 
         self.storyMenu.AppendSeparator()
@@ -791,7 +794,11 @@ jQuery: off
 
 Modernizr: off
 """
-        
+
+        elif id == self.STORYSETTINGS_INIT:
+            defaultText = "This passage's contents will be evaluated on story (re)start, before the first passage is shown. " \
+                          "It is a good place to initialize variables."
+
         for widget in self.storyPanel.widgets:
             if widget.passage.title == title:
                 found = True
@@ -1242,7 +1249,7 @@ Modernizr: off
     
     [STORY_NEW_PASSAGE, STORY_NEW_SCRIPT, STORY_NEW_STYLESHEET, STORY_NEW_ANNOTATION, STORY_EDIT_FULLSCREEN, STORY_STATS, \
      STORY_IMPORT_IMAGE, STORY_IMPORT_IMAGE_URL, STORY_IMPORT_FONT, STORY_FORMAT_HELP, STORYSETTINGS_START, STORYSETTINGS_TITLE, STORYSETTINGS_SUBTITLE, STORYSETTINGS_AUTHOR, \
-     STORYSETTINGS_MENU, STORYSETTINGS_SETTINGS, STORYSETTINGS_INCLUDES] = range(401,418)
+     STORYSETTINGS_MENU, STORYSETTINGS_SETTINGS, STORYSETTINGS_INCLUDES, STORYSETTINGS_INIT] = range(401,419)
     
     STORY_FORMAT_BASE = 501
     

--- a/targets/engine.js
+++ b/targets/engine.js
@@ -102,6 +102,8 @@ function throwError(a, b, tooltip) {
     if (a) {
         var elem = insertElement(a, "span", null, "marked", b);
         tooltip && elem.setAttribute("title", tooltip);
+    } else {
+        alert("There is a technical problem with this story: " + b + "."+softErrorMessage);
     }
 }
 Math.easeInOut = function (a) {
@@ -2108,7 +2110,11 @@ function main() {
             sanityCheck('init() of the custom macro "'+i+'"');
         }
     }
-    
+
+    if (tale.has("StoryInit")) {
+        new Wikifier(null, tale.get("StoryInit").text);
+    }
+
     style = document.getElementById("storyCSS");
     for (i in tale.passages) {
         i = tale.passages[i];

--- a/tiddlywiki.py
+++ b/tiddlywiki.py
@@ -292,7 +292,8 @@ class TiddlyWiki:
 		
 		return tiddler
 	
-	FORMATTED_INFO_PASSAGES = frozenset(['StoryMenu', 'StoryTitle', 'StoryAuthor', 'StorySubtitle'])
+	FORMATTED_INFO_PASSAGES = frozenset([
+			'StoryMenu', 'StoryTitle', 'StoryAuthor', 'StorySubtitle', 'StoryInit'])
 	UNFORMATTED_INFO_PASSAGES = frozenset(['StoryIncludes', 'StorySettings'])
 	INFO_PASSAGES = FORMATTED_INFO_PASSAGES | UNFORMATTED_INFO_PASSAGES
 	SPECIAL_TAGS = frozenset(['Twine.image'])


### PR DESCRIPTION
See this discussion thread: http://twinery.org/forum/index.php/topic,1412.0.html

Please carefully review the JavaScript part of the changes. I didn't find any problems while testing, but I only tested the new functionality, so regressions in old functionality could exist. In particular:

I'm passing "null" for the output element and I changed "throwError" to show an alert box if there is no element to attach the error message to. Previously errors would be ignored if the element was null. In general I think it is better to complain loudly on errors instead of hiding them, but I don't know if there is maybe some existing code that relies on the errors being suppressed. 

Passing "null" as the output doesn't cause any problems, since Wikifier's outputText() is not called when processing a full string. However, I don't know whether that is something that can be safely relied on, or something that might change in the future.

I had this in an earlier version; it is a bit more defensive, but maybe unnecessarily so:

```
if (tale.has("StoryInit")) {
    function InitWikifier(source) {
        this.outputText = function (place, startPos, endPos) { };
        Wikifier.call(this, null, source);
    }
    InitWikifier.prototype = Wikifier.prototype;
    new InitWikifier(tale.get("StoryInit").text);
}
```
