### PR TITLE
PassageFrame Title field hides staring characters

### DIFF
--- a/passageframe.py
+++ b/passageframe.py
@@ -211,6 +211,10 @@ class PassageFrame(wx.Frame):
             self.bodyInput.SetFocus()
             self.bodyInput.SetSelection(-1, -1)
 
+        # Hack to force titles (>18 char) to display correctly.
+        # NOTE: stops working if moved above bodyInput code. 
+        self.titleInput.SetInsertionPoint(0)
+
         self.SetIcon(self.app.icon)
         self.Show(True)
 


### PR DESCRIPTION
The **_Title**_ field in **_Passage Frame**_ does not always show the whole value.

When viewing an existing Passage with a title that is longer than eighteen (18) characters (including white-space) in length then only the last eighteen (18) characters will be visible. The first character(s) can only be seen if you place the cursor within the field and move it to the start of the value.

eg:
a. Passage title of **_abcdefghijklmnopqr**_ appears in field as **_abcdefghijklmnopqr**_
b. Passage title of **_abcdefghijklmnopqrs**_ appears in field as **_bcdefghijklmnopqrs**_, the **_a**_ is hidden.

NOTE:
1. The actual number of characters where this effect starts occurring may vary based on OS and version of Python / wxPython , for me it was eighteen. 
2. This is a [known problem](http://wxpython-users.1045709.n5.nabble.com/text-cut-off-in-single-line-wxTextCtrl-td2290141.html)
