### PR TITLE
Tweelexer and external passages

### DIFF
--- a/passageframe.py
+++ b/passageframe.py
@@ -615,6 +615,8 @@ class PassageFrame(wx.Frame):
                         found = True
                         break
 
+                if not found and self.widget.parent.externalPassageExists(link): found = True
+
                 if not found: broken.append(link)
 
         # incoming links

--- a/passagewidget.py
+++ b/passagewidget.py
@@ -160,7 +160,7 @@ class PassageWidget:
 
     def getBrokenLinks(self):
         """Returns a list of broken links in this widget."""
-        return filter(lambda a: not self.parent.findWidget(a), self.passage.links)
+        return filter(lambda a: not self.parent.findWidget(a) and not self.parent.externalPassageExists(a), self.passage.links)
 
     def setSelected(self, value, exclusive = True):
         """

--- a/storyframe.py
+++ b/storyframe.py
@@ -863,6 +863,7 @@ You can also include URLs of .tws and .twee files, too.
         
         excludepassages = TiddlyWiki.INFO_PASSAGES
         excludetags = TiddlyWiki.NOINCLUDE_TAGS
+        self.storyPanel.clearExternalPassages()
         for line in lines:
             try:
                 if line.strip():
@@ -887,6 +888,8 @@ You can also include URLs of .tws and .twee files, too.
                                     raise Exception('A passage titled "'+ widget.passage.title + '" has been included by a previous StoryIncludes file')
 
                                 tw.addTiddler(widget.passage)
+                                self.storyPanel.addExternalPassage(widget.passage.title)
+
                         s.Destroy()
 
                     elif extension == '.tw' or extension == '.txt' or extension == '.twee':
@@ -913,6 +916,8 @@ You can also include URLs of .tws and .twee files, too.
                             if passage.title not in excludepassages \
                             and excludetags.isdisjoint(passage.tags):
                                 tw.addTiddler(passage)
+                                self.storyPanel.addExternalPassage(passage.title)
+
                     else:
                         raise Exception('File format not recognized')
             except:

--- a/storypanel.py
+++ b/storypanel.py
@@ -28,6 +28,7 @@ class StoryPanel(wx.ScrolledWindow):
 
         self.snapping = self.app.config.ReadBool('storyPanelSnap')
         self.widgets = []
+        self.externalPassages = set()
         self.draggingMarquee = False
         self.draggingWidgets = None
         self.notDraggingWidgets = None
@@ -696,6 +697,29 @@ class StoryPanel(wx.ScrolledWindow):
         for widget in self.widgets:
             if widget.passage.title == title: return widget
         return None
+
+    def passageExists(self, title, includeExternal = False):
+        """
+        Returns whether a given passage exists in the story.
+        
+        If includeExternal then will also check external passages referenced via StoryIncludes
+        """
+        found = (self.findWidget(title) != None)
+        if not found and includeExternal:
+            found = self.externalPassageExists(title)
+        return found
+
+    def clearExternalPassages(self):
+        """Clear the externalPassages set"""
+        self.externalPassages.clear()
+
+    def addExternalPassage(self, title):
+        """Add a title to the set of external passages"""
+        self.externalPassages.add(title)
+
+    def externalPassageExists(self, title):
+        """Add a title to the set of external passages"""
+        return (title in self.externalPassages)
 
     def toPixels(self, logicals, scaleOnly = False):
         """

--- a/tweelexer.py
+++ b/tweelexer.py
@@ -317,7 +317,7 @@ class TweeLexer:
         """
         Returns whether a given passage exists in the story.
         """
-        return (self.frame.widget.parent.findWidget(title) != None)
+        return (self.frame.widget.parent.passageExists(title, True))
 
     def applyStyle(self, start, end, style):
         """


### PR DESCRIPTION
Story Authors use the StoryIncludes feature to get around the Twine GUI's problem of displaying TWS files containing a large number of Passages.
A side-effect of doing this is that the TweeLexer incorrectly marks any links to these external passages as broken / non-existing.

This patch parses the TWS/TS/TXT files referenced within StoryIncludes, stores the passage names found within these files and uses this set when searching to see if a passage title exists.

It does the following:
- Populate externalPassages set using existing buildIncludes method.
- Lexer highlights link to found external passage as good.
- Remove found external passages from broken links list.
- Dont show broken link emblem if all internal and external passages found.

NOTE:
- Currently the user has to use one of the build menu items ("Build Story" or "Rebuild Story") to populate the set, after which the UI will correctly handle links to external passages. This could be changed to happen when a TWS file is initially opened.
- The set of externalPassages is NOT persisted within the story pickle.
- A StoryPanel.paint call is required to update all the resolved broken link emblems, which this code does NOT currently do because I don't know the ramification. Clicking on an individual passage widget will update it.
