### PR TITLE
Fixes a bug in the StoryIncludes code.

### DIFF
--- a/storyframe.py
+++ b/storyframe.py
@@ -918,10 +918,10 @@ You can also include URLs of .tws and .twee files, too.
             self.app.displayError('building your story')
     
     def getLocalDir(self):
-        if self.saveDestination == '':
-            return os.getcwd()
-        else:
-            return os.path.dirname(self.saveDestination)
+        dir = (self.saveDestination != '' and os.path.dirname(self.saveDestination)) or None
+        if not os.path.isdir(dir):
+            dir = os.getcwd()
+        return dir
     
     def readIncludes(self, lines, callback):
         """


### PR DESCRIPTION
Fixes a bug in the StoryIncludes code, which is triggered if a save destination exists but is not a valid directory.  The user could have modified their paths, sent the TWS to someone else, etc.
