### PR TITLE
Update to allow HTML character references to be properly utilized.

### DIFF
--- a/targets/engine.js
+++ b/targets/engine.js
@@ -2032,6 +2032,16 @@ Wikifier.formatters = [
     }
 },
 {
+	name: "htmlCharacterReference",
+	match: "(?:(?:&#?[a-zA-Z0-9]{2,8};|.)(?:&#?(?:x0*(?:3[0-6][0-9a-fA-F]|1D[c-fC-F][0-9a-fA-F]|20[d-fD-F][0-9a-fA-F]|FE2[0-9a-fA-F])|0*(?:76[89]|7[7-9][0-9]|8[0-7][0-9]|761[6-9]|76[2-7][0-9]|84[0-3][0-9]|844[0-7]|6505[6-9]|6506[0-9]|6507[0-1]));)+|&#?[a-zA-Z0-9]{2,8};)",
+	handler: function(w)
+	{
+		var el = document.createElement("div");
+		el.innerHTML = w.matchText;
+		insertText(w.output, el.textContent);
+	}
+},
+{
     name: "htmltag",
     match: "<(?:\\/?[\\w\\-]+|[\\w\\-]+(?:(?:\\s+[\\w\\-]+(?:\\s*=\\s*(?:\\\".*?\\\"|'.*?'|[^'\\\">\\s]+))?)+\\s*|\\s*)\\/?)>",
     tagname: "<(\\w+)",

--- a/tiddlywiki.py
+++ b/tiddlywiki.py
@@ -631,8 +631,10 @@ class Tiddler:
 
 def encode_text(text):
     """Encodes a string for use in HTML output."""
-    output = text.replace('\\', '\s') \
+    output = text \
+        .replace('\\', '\s') \
         .replace('\t', '\\t') \
+        .replace('&', '&amp;') \
         .replace('<', '&lt;') \
         .replace('>', '&gt;') \
         .replace('"', '&quot;') \
@@ -642,12 +644,14 @@ def encode_text(text):
 
 def decode_text(text):
     """Decodes a string from HTML."""
-    return text.replace('\\n', '\n') \
+    return text \
+        .replace('\\n', '\n') \
         .replace('\\t', '\t') \
         .replace('\s', '\\') \
-        .replace('&lt;', '<') \
+        .replace('&quot;', '"') \
         .replace('&gt;', '>') \
-        .replace('&quot;', '"')
+        .replace('&lt;', '<') \
+        .replace('&amp;', '&')
 
 def encode_date(date):
     """Encodes a datetime in TiddlyWiki format."""


### PR DESCRIPTION
As an example.  Previously, it was impossible to do something like `&lt;&lt;foo&gt;&gt;` in your Twine markup and have it rendered properly.  Instead, it would be decoded into `<<foo>>` and mistaken for a macro call.
