### PR TITLE
Modified the way that story metadata tags are added to headers.

### DIFF
--- a/targets/Responsive/header.html
+++ b/targets/Responsive/header.html
@@ -3,6 +3,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
 <head>
 <meta charset="utf-8">
+<title>Responsive</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <!--
 "VERSION"
@@ -43,7 +44,6 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 -->
-<title>Responsive</title>
 <script title="engine">
 (function(){
 

--- a/targets/jonah/header.html
+++ b/targets/jonah/header.html
@@ -3,6 +3,7 @@
 <!--[if gt IE 8]><!--><html><!--<![endif]-->
 <head>
 <meta charset="utf-8">
+<title>Jonah</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <!--
 "VERSION"
@@ -41,7 +42,6 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 -->
-<title>Jonah</title>
 <script title="engine">
 (function(){
 

--- a/targets/sugarcane/header.html
+++ b/targets/sugarcane/header.html
@@ -3,6 +3,7 @@
 <!--[if gt IE 8]><!--><html><!--<![endif]-->
 <head>
 <meta charset="utf-8">
+<title>Sugarcane</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <!--
 "VERSION"
@@ -41,7 +42,6 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 -->
-<title>Sugarcane</title>
 <script title="engine">
 (function(){
 

--- a/tiddlywiki.py
+++ b/tiddlywiki.py
@@ -126,8 +126,7 @@ class TiddlyWiki:
                 metatags += '<meta name="' + name.replace('"','&quot;') + '" content="' + content.replace('"','&quot;') + '">\n'
         
         if metatags:
-            # Just gonna assume <head> contains no attributes containing > symbols.
-            output = re.sub(r'<head[^>]*>\s*\n?', lambda a: a.group(0) + metatags, output, flags=re.I, count=1)
+            output = re.sub(r'<\/title>\s*\n?', lambda a: a.group(0) + metatags, output, flags=re.I, count=1)
 
         # Check if the scripts are personally requesting jQuery or Modernizr
         jquery = 'jquery' in self.storysettings and self.storysettings['jquery'] != "off"


### PR DESCRIPTION
The character set specification should be the very first thing within the header, next should be the `<title>` tag, only then should additional `<meta>` tags be specified (the first of which should probably be "description" if you're worried about search engines parsing it).

With that in mind, I:
- Moved `<title>…</title>` to just after character set specification in the vanilla headers.
- Modified the insertion code to add story metadata tags after the closing `</title>` tag.
