### PR TITLE
Fixed an order of operations issue with remember.init() and tale.title.

### DIFF
--- a/targets/engine.js
+++ b/targets/engine.js
@@ -2391,6 +2391,9 @@ function main() {
             }
         }
     }
+    // Need to make an initial call to setPageElements() to define tale.title,
+    // since it's used by remember.init()
+	tale.setPageElements();
     // Run all script passages
     scripts = tale.lookup("tags", "script");
     for (i = 0; i < scripts.length; i++) {


### PR DESCRIPTION
The vanilla headers have an order of operations bug related to `remember.init()` and `tale.title`.  At the time macros' `init()` methods are called, `tale.setPageElements()` has yet to be called, meaning that `tale.title` is undefined.

This bug causes `macros.remember.prefix` to be set to `"Twine.undefined."`, which could lead to remembered $variables from one story/game being read and/or overwritten by another, if they have the same name (e.g. $foo is `"Twine.undefined.foo"` in all stories/games).
