### PR TITLE
Exclude embedded images from the Proofing Copy RTF

### DIFF
--- a/storyframe.py
+++ b/storyframe.py
@@ -1129,7 +1129,9 @@ You can also include URLs of .tws and .twee files, too.
 
             tw = TiddlyWiki()
             for widget in self.storyPanel.sortedWidgets():
-                tw.addTiddler(widget.passage)
+                # Exclude images from RTF, they appear as large unreadable blobs of base64 text. 
+                if 'Twine.image' not in widget.passage.tags:
+                    tw.addTiddler(widget.passage)
 
             order = map(lambda w: w.passage.title, self.storyPanel.sortedWidgets())
             dest.write(tw.toRtf(order))

--- a/tiddlywiki.py
+++ b/tiddlywiki.py
@@ -228,6 +228,9 @@ class TiddlyWiki:
         # content
 
         for i in order:
+            # Handle the situation where items are in the order set but not in the tiddlers set.
+            if i not in self.tiddlers:
+                continue
             text = rtf_encode(self.tiddlers[i].text)
             text = re.sub(r'\n', '\\\n', text) # newlines
             text = re.sub(tweeregex.LINK_REGEX, r'\\b\cf2 \ul \1\ulnone \cf0 \\b0 ', text) # links


### PR DESCRIPTION
Embedded images appear as a large unreadable blobs of base64 text in the Proofing Copy RTF file.
Because of this I believe it makes more sense to exclude the images from the generated RTF, which will improve file loading and spell checking of the contents.
