### PR TITLE
Twee error handling fixes

### DIFF
--- a/twee
+++ b/twee
@@ -90,7 +90,9 @@ def main(argv):
     # generate output
 
     output = tw.toHtml(app, header, order, startAt = start)
-    if sys.stdout.isatty():
+    if output is None:
+        print >> sys.stderr, 'twee: no output'
+    elif sys.stdout.isatty():
         print output
     else:
         print output.encode('utf_8_sig')


### PR DESCRIPTION
Add 'stacktrace' argument to displayError(): this was added to the base class but not yet to Twee.
Handle None output gracefully; this can happen when there are errors running Twee.
