### PR TITLE
Store twine passage position information in modified .twee file

### DIFF
--- a/app.py
+++ b/app.py
@@ -250,7 +250,8 @@ class App(wx.App):
             'displayArrows' : True,
             'createPassagePrompt' : True,
             'importImagePrompt' : True,
-            'passageWarnings' : True
+            'passageWarnings' : True,
+            'saveTwinePosition' : False
         }.iteritems():
             if not sc.HasEntry(k):
                 if type(v) == str:

--- a/prefframe.py
+++ b/prefframe.py
@@ -15,7 +15,7 @@ class PreferenceFrame(wx.Frame):
         panel = wx.Panel(parent = self, id = wx.ID_ANY)
         borderSizer = wx.BoxSizer(wx.VERTICAL)
         panel.SetSizer(borderSizer)
-        panelSizer = wx.FlexGridSizer(14, 2, metrics.size('relatedControls'), metrics.size('relatedControls'))
+        panelSizer = wx.FlexGridSizer(15, 2, metrics.size('relatedControls'), metrics.size('relatedControls'))
         borderSizer.Add(panelSizer, flag = wx.ALL, border = metrics.size('windowBorder'))
 
         self.editorFont = wx.FontPickerCtrl(panel, style = wx.FNTP_FONTDESC_AS_LABEL)
@@ -67,6 +67,7 @@ class PreferenceFrame(wx.Frame):
         checkbox(self, "createPassagePrompt", 'Offer to create new passages for broken links')
         checkbox(self, "importImagePrompt", 'Offer to import externally linked images')
         checkbox(self, "passageWarnings", 'Warn about possible passage code errors')
+        checkbox(self, "saveTwinePosition", 'Save twine position data in twee source')
 
         panelSizer.Add(wx.StaticText(panel, label = 'Normal Font'), flag = wx.ALIGN_CENTER_VERTICAL)
         panelSizer.Add(self.editorFont)
@@ -96,6 +97,8 @@ class PreferenceFrame(wx.Frame):
         panelSizer.Add(self.importImagePrompt) # pylint: disable=no-member
         panelSizer.Add((1,2))
         panelSizer.Add(self.passageWarnings) # pylint: disable=no-member
+        panelSizer.Add((1,2))
+        panelSizer.Add(self.saveTwinePosition) # pylint: disable=no-member
 
         panelSizer.Fit(self)
         borderSizer.Fit(self)

--- a/storyframe.py
+++ b/storyframe.py
@@ -547,7 +547,7 @@ class StoryFrame(wx.Frame):
                     tw.addTiddler(widget.passage)
                 dest = codecs.open(path, 'w', 'utf-8-sig', 'replace')
                 order = [widget.passage.title for widget in self.storyPanel.sortedWidgets()]
-                dest.write(tw.toTwee(order))
+                dest.write(tw.toTwee(order, self.app.config.ReadBool('saveTwinePosition')))
                 dest.close()
             except:
                 self.app.displayError('exporting your source code')

--- a/tiddlywiki.py
+++ b/tiddlywiki.py
@@ -25,16 +25,18 @@ class TiddlyWiki(object):
     def hasTiddler(self, name):
         return name in self.tiddlers
 
-    def toTwee(self, order = None):
+    def toTwee(self, order = None, saveTwinePosition=False):
         """Returns Twee source code for this TiddlyWiki.
         The 'order' argument is a sequence of passage titles specifying the order
         in which passages should appear in the output string; by default passages
         are returned in arbitrary order.
+        If saveTwinePosition is True the twee source code will include metadata 
+        with the location of the passage in the twine storypanel.
         """
         tiddlers = self.tiddlers
         if order is None:
             order = tiddlers.keys()
-        return u''.join(tiddlers[i].toTwee() for i in order)
+        return u''.join(tiddlers[i].toTwee(saveTwinePosition) for i in order)
 
     def read(self, filename):
         try:
@@ -406,12 +408,12 @@ class Tiddler: # pylint: disable=old-style-class
                     val = keyval_bits[1].strip()
                     if key == 'twine-pos-x':
                         try:
-                            self.pos[0] = int(val)
+                            self.pos[0] = float(val)
                         except ValueError:
                             continue
                     elif key == 'twine-pos-y':
                         try:
-                            self.pos[1] = int(val)
+                            self.pos[1] = float(val)
                         except ValueError:
                             continue
 
@@ -534,8 +536,10 @@ class Tiddler: # pylint: disable=old-style-class
             )
 
 
-    def toTwee(self):
-        """Returns a Twee representation of this tiddler."""
+    def toTwee(self, saveTwinePosition=False):
+        """Returns a Twee representation of this tiddler.  If saveTwinePosition is 
+        True the location of the passagewidget will be stored in the twee source.
+        """
         output = u':: ' + self.title
 
         if len(self.tags) > 0:
@@ -544,9 +548,10 @@ class Tiddler: # pylint: disable=old-style-class
                 output += tag + ' '
             output = output.strip()
             output += u']'
-        else:
+        elif saveTwinePosition:
             output += u' []'
-        output += u'[twine-pos-x:%s, twine-pos-y:%s]' % (self.pos[0], self.pos[1])
+        if saveTwinePosition:
+            output += u'[twine-pos-x:%s, twine-pos-y:%s]' % (self.pos[0], self.pos[1])
 
         output += u"\n" + self.text + u"\n\n\n"
         return output


### PR DESCRIPTION
While searching for information to facilitate editing in an external program without loosing the graph I came across this conversations:

http://twinery.org/forum/index.php?topic=1403.0

which pretty much said what I was looking for was not currently implemented.  However it did give me enough information to suggest it was very doable.  So I did.  I don't know if this is of use to anyone else or just myself and being new to the twine community I wasn't sure if this is something that is generally wanted or if there is some other plan to handle the issue.

I created a new preference.  Unfortunately I couldn't seem to get it to default to False.  If someone can point me to what I'm missing I'll fix it.

This patch creates a new section in a passage after the tags containing key value pairs.  At present it handles 'twine-pos-x' and 'twine-pos-y'.  If you do export to twee (while the pref is set) it will populate those values in the twee file.  Import from twee will similarly read them and place the passage widgets according to those values. 

Standard twee files continue to work and if the pref is set to false standard twee files can still be generated. 
