### PR TITLE
Paste Passage Here context menu incorrectly places new passage

### DIFF
--- a/storypanel.py
+++ b/storypanel.py
@@ -166,7 +166,7 @@ class StoryPanel(wx.ScrolledWindow):
         self.removeWidgets()
         self.Refresh()
 
-    def pasteWidgets(self, pos = (0,0)):
+    def pasteWidgets(self, pos = (0,0), logicals = False):
         """Pastes widgets from the clipboard."""
         clipFormat = wx.CustomDataFormat(StoryPanel.CLIPBOARD_FORMAT)
         clipData = wx.CustomDataObject(clipFormat)
@@ -180,11 +180,15 @@ class StoryPanel(wx.ScrolledWindow):
 
                 self.eachWidget(lambda w: w.setSelected(False, False))
 
+                if not pos: pos = StoryPanel.INSET
+                if not logicals: pos = self.toLogical(pos)
+
                 for widget in data:
                     newPassage = PassageWidget(self, self.app, state = widget, pos = pos, title = self.untitledName(widget['passage'].title))
                     newPassage.findSpace()
                     newPassage.setSelected(True, False)
                     self.widgetDict[newPassage.passage.title] = newPassage
+                    self.snapWidget(newPassage, False)
 
                 self.parent.setDirty(True, action = 'Paste')
                 self.resize()


### PR DESCRIPTION
As reported on the [twine forums](http://twinery.org/forum/index.php/topic,1409.msg4787.html#msg4787), the "Paste Passage Here" context menu incorrectly places the new passage which is a result of the x,y position co-ords not being converted from Frame based to Logical.
There is also a related issue of the new passage not being snapped to the screen grid.

This fix changed the pasteWidgets method to handle position and snapWidget the same way the newWidget method does.
