### PR TITLE
Fixed the problem of not being able to change the passage title.

### DIFF
--- a/passageframe.py
+++ b/passageframe.py
@@ -271,9 +271,10 @@ class PassageFrame(wx.Frame):
             self.titleInvalid = True
 
         if title:
-        # Check for title conflict
+            # Check for title conflict
             otherTitled = self.widget.parent.findWidget(title)
-            if otherTitled is not self.widget:
+            # WARNING: findWidget returns None if title not found so need to check otherTitled has value.
+            if otherTitled and otherTitled is not self.widget:
                 self.titleLabel.SetLabel("Title is already in use!")
                 error()
             elif self.widget.parent.includedPassageExists(title):


### PR DESCRIPTION
Patch "Various cleanups related to findWidget" by Maarten ter Huurne incorrectly removed a check of the otherTitled variable to determine if it had a value, this check is actually needed because the call to findWidget returns None if the title is not found.
