### PR TITLE
Font import improvements:

### DIFF
--- a/images.py
+++ b/images.py
@@ -9,20 +9,20 @@ def addURIPrefix(text, mimeType):
     # SVG MIME-type is the same for both images and fonts
     mimeType = mimeType.lower()
     if mimeType in 'gif|jpg|jpeg|png|webp|svg':
-        mimeGroup = "image/"
-    elif mimeType == 'woff':
-        mimeGroup = "application/font-"
+        # Correct certain MIME types
+        if mimeType == 'jpg':
+            mimeType = "jpeg"
+        elif mimeType == 'svg':
+            mimeType += "+xml"
+        mimeType = "image/" + mimeType
+    elif mimeType in 'woff|woff2':
+        mimeType = "application/font-" + mimeType
     elif mimeType in 'ttf|otf':
-        mimeGroup = "application/x-font-"
+        mimeType = "application/font-sfnt"
     else:
-        mimeGroup = "application/octet-stream"
+        mimeType = "application/octet-stream"
 
-    # Correct certain MIME types
-    if mimeType == "jpg":
-        mimeType = "jpeg"
-    elif mimeType == "svg":
-        mimeType += "+xml"
-    return "data:" + mimeGroup + mimeType + ";base64," + text
+    return "data:" + mimeType + ";base64," + text
 
 def removeURIPrefix(text):
     """Removes the Data URI part of the base64 data"""

--- a/storypanel.py
+++ b/storypanel.py
@@ -1173,7 +1173,7 @@ class StoryPanelDropTarget(wx.PyDropTarget):
                     elif fname.endswith(".html") or fname.endswith(".htm"):
                         self.panel.parent.importHtml(file)
                     elif re.search(imageRegex, fname):
-                        text, title = self.panel.parent.openFileAsBase64(fname)
+                        text, title = self.panel.parent.openFileAsBase64(fname)[:2]
                         imagesImported += 1 if self.panel.parent.finishImportImage(text, title, showdialog = not multipleImages) else 0
 
                 if imagesImported > 1:


### PR DESCRIPTION
- Fixes improper MIME-type for TTF/OTF fonts.
- Adds `format()` hint component (generally, more useful than the MIME-type).
- Adds support for WOFF2 for future proofing (even though it's too new to be useful embedded).

WOULDN'T THAT BE NICE: Allowing selection of multiple formats for a single font and having Twine 1 do the correct thing would be nice.  However, keeping users from simply selecting multiple different fonts could be problematic.  I suppose, simply requiring that the base filenames must be the same could be a solution.