### PR TITLE
Test/Debug Mode update.

### DIFF
--- a/storyframe.py
+++ b/storyframe.py
@@ -869,7 +869,7 @@ You can also include URLs of .tws and .twee files, too.
 
         dialog.Destroy()
 
-    def testBuild(self, event=None, startAt=''):
+    def testBuild(self, event=None, startAt='Start'):
         self.rebuild(temp=True, startAt=startAt, displayAfter=True)
 
     def rebuild(self, event=None, temp=False, displayAfter=False, startAt=''):


### PR DESCRIPTION
Changed the default value of the `startAt` parameter of `testBuild()` to `'Start'`, so the test play string replacement (`"START_AT"`) will always have a value during test plays.  Story formats may use this to detect a test play and enable any test/debug mode they may have.