### PR TITLE
Re-direct the Twine 2 repos hyperlink in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Twine 1 development is presently resigned to bugfixes and maintenance - although
 contributions for new features may still be considered for acceptance.
 
 A web-application "sequel" to Twine 1, called Twine 2, is in active development.
-Its repositories are [here](https://bitbucket.com/klembot/twinejs) and [here](https://bitbucket.com/_L_/harlowe).
+Its repositories are [here](https://github.com/klembot/twinejs) and [here](https://foss.heptapod.net/games/harlowe/).
 
 Installation
 ------------


### PR DESCRIPTION
Re-direct the twinejs link to the project's GitHub and the Harlowe link to the project's GitLab.